### PR TITLE
Add ability to call Analytics.page.

### DIFF
--- a/angular-segmentio.js
+++ b/angular-segmentio.js
@@ -24,7 +24,7 @@ angular.module('segmentio', ['ng'])
 
         // Loop through analytics.js' methods and generate a wrapper method for each.
         var methods = ['identify', 'track', 'trackLink', 'trackForm', 'trackClick',
-            'trackSubmit', 'pageview', 'ab', 'alias', 'ready', 'group'];
+            'trackSubmit', 'page', 'pageview', 'ab', 'alias', 'ready', 'group'];
         for (var i = 0; i < methods.length; i++) {
             service[methods[i]] = methodFactory(methods[i]);
         }

--- a/test/unit/angularSegmentIoSpec.js
+++ b/test/unit/angularSegmentIoSpec.js
@@ -40,6 +40,10 @@ describe('Segment IO', function () {
 		expect(segmentio.trackSubmit).toBeDefined();
 	}));
 
+	it('should have a page method after loading', inject(function (segmentio) {
+		expect(segmentio.page).toBeDefined();
+	}));
+
 	it('should have a pageview method after loading', inject(function (segmentio) {
 		expect(segmentio.pageview).toBeDefined();
 	}));


### PR DESCRIPTION
This allows the user to use the named page tracking API introduced in release 
1.0.0 of segmentio/analtyics.js.

This new API is mentioned in the migration notes:
   (https://github.com/segmentio/analytics.js/wiki/Migrating-to-1.0.0)

Details about the API change are in issue #153:
   (https://github.com/segmentio/analytics.js/issues/153)
