### PR TITLE
Make plugin work with segment.io 3.0.0

### DIFF
--- a/angular-segmentio.js
+++ b/angular-segmentio.js
@@ -3,9 +3,23 @@ angular.module('segmentio', ['ng'])
         function($rootScope, $window, $location, $log) {
             var service = {};
 
-            //Create a temp queue for events fired before analytics loaded
-            //but do not attempt to create 'analytics' object.
+            // Create a temp queue for events fired before analytics loaded
+            // but do not attempt to create 'analytics' object.
             var tempQueue = [];
+
+
+            function flushTempQueue () {
+                if (tempQueue.length) {
+                    // Send the queue of pending events
+                    $window.analytics.push.apply($window.analytics, tempQueue)
+                    tempQueue.length = 0
+                }
+            }
+
+            //  Analytics script is loaded callback.
+            var analyticsLoaded = function() {
+                flushTempQueue()
+            }
 
             // Define a factory that generates wrapper methods to push arrays of
             // arguments onto our `analytics` queue, where the first element of the arrays
@@ -14,13 +28,10 @@ angular.module('segmentio', ['ng'])
                 return function() {
                     var args = Array.prototype.slice.call(arguments, 0);
                     $log.debug('Call segmentio API with', type, args);
+
                     //Because we didn't overwrite the analytics object we can use
                     //its presence as a flag that segment.io has loaded.
                     if ($window.analytics) {
-                        if (tempQueue.length) {
-                            $window.analytics.push.apply($window.analytics, tempQueue)
-                            tempQueue.length = 0
-                        }
                         $log.debug('Segmentio API initialized, calling API');
                         $window.analytics[type].apply($window.analytics, args);
                     } else {
@@ -58,6 +69,7 @@ angular.module('segmentio', ['ng'])
                 script.async = true;
                 script.src = ('https:' === document.location.protocol ? 'https://' : 'http://') +
                     'd2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/' + apiKey + '/analytics.js';
+                script.onload = analyticsLoaded
 
                 // Find the first script element on the page and insert our script next to it.
                 var firstScript = document.getElementsByTagName('script')[0];


### PR DESCRIPTION
This code no longer tries to mock the analytics object, because when it happens the mock object doesn't get assigned the 'initialized' property correctly. This is also a deprecated flag in segmentio. Instead it uses the presence of analytics as signal to resend the queue of events and start proxying them to the library.
